### PR TITLE
Changed header guards to allow for Windows compilation

### DIFF
--- a/envs/x86/include/hal_time.h
+++ b/envs/x86/include/hal_time.h
@@ -1,5 +1,5 @@
-#ifndef _TIME_H_
-#define _TIME_H_
+#ifndef _HAL_TIME_H_
+#define _HAL_TIME_H_
 
 /*******************************************************************************
  * Includes


### PR DESCRIPTION
As title says, fixed compilation for windows by changing header guards in ```time.h``` to ensure no overlap between system headers. 