### PR TITLE
fix typo externl to external

### DIFF
--- a/doc/x86-Compilation.md
+++ b/doc/x86-Compilation.md
@@ -48,7 +48,7 @@ sudo apt install cmake
 
 ### Install Submodules
 
-In order to compile the project for x86, we need to install a submodule — [Unity](https://github.com/ThrowTheSwitch/Unity) — which is used for unit testing. If you are cloning the project for the first time, you can pass `--recurse-submodules` when you `git clone`, but if you've already cloned the repository to your computer you need to run (from the project directoy, in your shell) `git submodule init` and then `git submodule update`. This lets git know that the empty folder in [externl](../external) called 'Unity' is a submodule, and then fills it up with what it should hold - the Unity unit testing framework.
+In order to compile the project for x86, we need to install a submodule — [Unity](https://github.com/ThrowTheSwitch/Unity) — which is used for unit testing. If you are cloning the project for the first time, you can pass `--recurse-submodules` when you `git clone`, but if you've already cloned the repository to your computer you need to run (from the project directoy, in your shell) `git submodule init` and then `git submodule update`. This lets git know that the empty folder in [external](../external) called 'Unity' is a submodule, and then fills it up with what it should hold - the Unity unit testing framework.
 
 ### Build Project
 


### PR DESCRIPTION
## Description

<!--- A (very brief!) summary of the changes and any related issue(s). Please include any relevant motivation and context. -->
Fixes a typo in x86 compilation.md where external was spelled "externl".
Fixes #59 

# Checklist:

- [x] My code follows the [style guidelines]([url](https://github.com/UBC-Rocket/Whistler-Blackcomb-v2/blob/master/doc/WritingCleanCode.md)) of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made any necessary changes to the documentation
- [x] I have added tests, where possible, that prove this change is effective or that this feature works (or n/a)
- [x] New and existing unit tests pass with my changes
